### PR TITLE
Print error message after calling usage

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -949,9 +949,10 @@ func Var(value Value, name, usage string, opts ...Opt) *Flag {
 // failf prints to standard error a formatted error and usage message and
 // returns the error.
 func (f *FlagSet) failf(format string, a ...interface{}) error {
-	err := fmt.Errorf(format, a...)
-	fmt.Fprintln(f.Output(), err)
 	f.usage()
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.Output())
+	fmt.Fprintln(f.Output(), err)
 	return err
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -1052,7 +1052,7 @@ func TestOutputExitOnError(t *testing.T) {
 	cmd.Stderr = mockStderr
 	err := cmd.Run()
 	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
-		want := "unknown flag: --unknown\nUsage of " + t.Name() + ":\n"
+		want := "Usage of " + t.Name() + ":\n\nunknown flag: --unknown\n"
 		if got := mockStderr.String(); got != want {
 			t.Errorf("got '%s', want '%s'", got, want)
 		}


### PR DESCRIPTION
<!-- Contributor License Notice :

By opening a pull request and making a contribution to this project, you certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.

-->

### Changes proposed in this pull request

Print error message after calling usage(). If the usage text is long then it is quite easy to miss the actual error. Printing the error afterwards makes more sense.

I am looking to adopt zflag in this program: https://github.com/stefansundin/shrimp

As you can see in the README, there are a lot of flags, and any error message printed before this long usage text will be easily missed. I think it makes a lot more sense printing it at the end.

I understand this may be a bit of a break in the behavior compared to the native flag package, but along with the other changes in zflag, this is a good change if you ask me.

### Checklist

- [x] Tests have been added and/or updated
- [x] `make test` has been run
- [x] `make lint` has been run

### A gif to brighten your reviewer's day and/or represents how you feel about this pull request

![](https://media.giphy.com/media/3o7aTskHEUdgCQAXde/giphy.gif)
