### PR TITLE
Move errors to separate error types

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,19 @@
 
 package zflag
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+func getFlagWithDashes(name string) string {
+	dash := "--"
+	if len(name) == 1 {
+		dash = "-"
+	}
+
+	return dash + name
+}
 
 type UnknownFlagError struct {
 	name string
@@ -17,4 +29,50 @@ func NewUnknownFlagError(name string) error {
 
 func (e UnknownFlagError) Error() string {
 	return fmt.Sprintf("unknown flag: %s", getFlagWithDashes(e.name))
+}
+
+type MissingFlagsError []string
+
+var _ error = (*MissingFlagsError)(nil)
+
+func (e *MissingFlagsError) AddMissingFlag(f *Flag) {
+	*e = append(*e, getFlagWithDashes(f.Name))
+}
+
+func (e MissingFlagsError) Error() string {
+	return fmt.Sprintf(`required flag(s) %q not set`, strings.Join(e, `, `))
+}
+
+type InvalidArgumentError struct {
+	flagName string
+	value    interface{}
+	err      error
+}
+
+var _ error = (*InvalidArgumentError)(nil)
+
+func NewInvalidArgumentError(err error, f *Flag, value interface{}) error {
+	var flagName string
+	if f.Shorthand != 0 && f.ShorthandDeprecated == "" {
+		flagName = fmt.Sprintf("-%c", f.Shorthand)
+		if !f.ShorthandOnly {
+			flagName = fmt.Sprintf("%s, --%s", flagName, f.Name)
+		}
+	} else {
+		flagName = getFlagWithDashes(f.Name)
+	}
+
+	return InvalidArgumentError{
+		flagName: flagName,
+		value:    value,
+		err:      err,
+	}
+}
+
+func (e InvalidArgumentError) Error() string {
+	return fmt.Sprintf("invalid argument %q for %q flag: %s", e.value, e.flagName, e.err)
+}
+
+func (e InvalidArgumentError) Unwrap() error {
+	return e.err
 }


### PR DESCRIPTION
### Changes proposed in this pull request

This PR moves some errors in `flag.go` to their own custom error types. This is so errors can be distinguished from easier.

### Checklist

- [x] Tests have been added and/or updated
- [x] `make test` has been run
- [x] `make lint` has been run
